### PR TITLE
 Make BPM usage configurable

### DIFF
--- a/jobs/cube_registry/monit
+++ b/jobs/cube_registry/monit
@@ -1,5 +1,13 @@
+<% if p("bpm.enabled") %>
 check process cube_registry
   with pidfile /var/vcap/sys/run/bpm/cube_registry/cube_registry.pid
   start program "/var/vcap/jobs/bpm/bin/bpm start cube_registry"
   stop program "/var/vcap/jobs/bpm/bin/bpm stop cube_registry"
   group vcap
+<% else %>
+check process cube_registry
+  with pidfile /var/vcap/sys/run/cube_registry/cube_registry.pid
+  start program "/var/vcap/jobs/cube_registry/bin/registry_ctl start"
+  stop program "/var/vcap/jobs/cube_registry/bin/registry_ctl stop"
+  group vcap
+<% end %>

--- a/jobs/cube_registry/spec
+++ b/jobs/cube_registry/spec
@@ -2,8 +2,16 @@
 name: cube_registry
 
 templates:
+  registry_ctl.erb: bin/registry_ctl
+  registry_as_vcap.erb: bin/registry_as_vcap
   bmp.yml.erb: config/bpm.yml
 
 packages:
+  - pid_utils
   - cube
   - cubefs
+
+properties:
+  bpm.enabled:
+    description: "Enable Bosh Process Manager"
+    default: false

--- a/jobs/cube_registry/templates/registry_as_vcap.erb
+++ b/jobs/cube_registry/templates/registry_as_vcap.erb
@@ -1,0 +1,13 @@
+#!/bin/bash -e
+
+run_dir=/var/vcap/sys/run/cube_registry
+log_dir=/var/vcap/sys/log/cube_registry
+conf_dir=/var/vcap/jobs/cube_registry/config
+pidfile=$run_dir/cube_registry.pid
+
+echo $$ > $pidfile
+
+exec /var/vcap/packages/cube/bin/cube registry \
+  --rootfs /var/vcap/jobs/cflinuxfs2-rootfs-setup/packages/cflinuxfs2/rootfs.tar \
+  2> >(tee -a $log_dir/cube_registry.stderr.log | logger -p user.error -t vcap.registry) \
+  1> >(tee -a $log_dir/cube_registry.stdout.log | logger -t vcap.registry)

--- a/jobs/cube_registry/templates/registry_ctl.erb
+++ b/jobs/cube_registry/templates/registry_ctl.erb
@@ -1,0 +1,39 @@
+#!/bin/bash -e
+
+run_dir=/var/vcap/sys/run/cube_registry
+log_dir=/var/vcap/sys/log/cube_registry
+conf_dir=/var/vcap/jobs/cube_registry/config
+
+pidfile=$run_dir/cube_registry.pid
+
+source /var/vcap/packages/pid_utils/pid_utils.sh
+
+case $1 in
+
+  start)
+    pid_guard $pidfile "cube_registry"
+
+    mkdir -p $run_dir
+    chown -R vcap:vcap $run_dir
+
+    mkdir -p $log_dir
+    chown -R vcap:vcap $log_dir
+
+    # Allowed number of open file descriptors
+    ulimit -n 100000
+
+    exec chpst -u vcap:vcap /var/vcap/jobs/cube_registry/bin/registry_as_vcap
+
+    ;;
+
+  stop)
+    kill_and_wait $pidfile
+
+    ;;
+
+  *)
+    echo "Usage: registry_ctl {start|stop}"
+
+    ;;
+
+esac

--- a/jobs/cube_stager/monit
+++ b/jobs/cube_stager/monit
@@ -1,5 +1,13 @@
+<% if p("bpm.enabled") %>
 check process cube_stager
   with pidfile /var/vcap/sys/run/bpm/cube_stager/cube_stager.pid
   start program "/var/vcap/jobs/bpm/bin/bpm start cube_stager"
   stop program "/var/vcap/jobs/bpm/bin/bpm stop cube_stager"
   group vcap
+<% else %>
+check process cube_stager
+  with pidfile /var/vcap/sys/run/cube_stager/cube_stager.pid
+  start program "/var/vcap/jobs/cube_stager/bin/stager_ctl start"
+  stop program "/var/vcap/jobs/cube_stager/bin/stager_ctl stop"
+  group vcap
+<% end %>

--- a/jobs/cube_stager/spec
+++ b/jobs/cube_stager/spec
@@ -2,13 +2,20 @@
 name: cube_stager
 
 templates:
+  stager_ctl.erb: bin/stager_ctl
+  stager_as_vcap.erb: bin/stager_as_vcap
   bmp.yml.erb: config/bpm.yml
   kube_config.erb: config/kube.yml
 
 packages:
+  - pid_utils
   - cube
 
 properties:
+  bpm.enabled:
+    description: "Enable Bosh Process Manager"
+    default: false
+
   cube_stager.ccAPI:
     description: "The API endpoint of the Cloud Controller"
   cube_stager.ccUser:

--- a/jobs/cube_stager/templates/bmp.yml.erb
+++ b/jobs/cube_stager/templates/bmp.yml.erb
@@ -14,6 +14,7 @@ processes:
     - <%= p('cube_stager.adminPassword') %>
     - --cube-address
     - <%= p('cube_stager.cube_address') %>
+    <% if p("cube_stager.skipSslValidation") %>- --skipSslValidation<% end %>
     limits:
       memory: 3G
       processes: 10

--- a/jobs/cube_stager/templates/stager_as_vcap.erb
+++ b/jobs/cube_stager/templates/stager_as_vcap.erb
@@ -1,0 +1,18 @@
+#!/bin/bash -e
+
+run_dir=/var/vcap/sys/run/cube_stager
+log_dir=/var/vcap/sys/log/cube_stager
+conf_dir=/var/vcap/jobs/cube_stager/config
+pidfile=$run_dir/cube_stager.pid
+
+echo $$ > $pidfile
+
+exec /var/vcap/packages/cube/bin/cube stage  \
+  --kubeconfig "$conf_dir/kube.yml" \
+  --cf-endpoint <%= p('cube_stager.ccAPI') %> \
+  --cf-username <%= p('cube_stager.adminUser') %> \
+  --cf-password <%= p('cube_stager.adminPassword') %> \
+  --cube-address <%= p('cube_stager.cube_address') %> \
+  <% if p("cube_stager.skipSslValidation") %>--skipSslValidation<% end %> \
+  2> >(tee -a $log_dir/cube_stager.stderr.log | logger -p user.error -t vcap.stager) \
+  1> >(tee -a $log_dir/cube_stager.stdout.log | logger -t vcap.stager)

--- a/jobs/cube_stager/templates/stager_ctl.erb
+++ b/jobs/cube_stager/templates/stager_ctl.erb
@@ -1,0 +1,39 @@
+#!/bin/bash -e
+
+run_dir=/var/vcap/sys/run/cube_stager
+log_dir=/var/vcap/sys/log/cube_stager
+conf_dir=/var/vcap/jobs/cube_stager/config
+
+pidfile=$run_dir/cube_stager.pid
+
+source /var/vcap/packages/pid_utils/pid_utils.sh
+
+case $1 in
+
+  start)
+    pid_guard $pidfile "cube_stager"
+
+    mkdir -p $run_dir
+    chown -R vcap:vcap $run_dir
+
+    mkdir -p $log_dir
+    chown -R vcap:vcap $log_dir
+
+    # Allowed number of open file descriptors
+    ulimit -n 100000
+
+    exec chpst -u vcap:vcap /var/vcap/jobs/cube_stager/bin/stager_as_vcap
+
+    ;;
+
+  stop)
+    kill_and_wait $pidfile
+
+    ;;
+
+  *)
+    echo "Usage: stager_ctl {start|stop}"
+
+    ;;
+
+esac

--- a/jobs/cube_sync/monit
+++ b/jobs/cube_sync/monit
@@ -1,5 +1,13 @@
+<% if p("bpm.enabled") %>
 check process cube_sync
   with pidfile /var/vcap/sys/run/bpm/cube_sync/cube_sync.pid
   start program "/var/vcap/jobs/bpm/bin/bpm start cube_sync"
   stop program "/var/vcap/jobs/bpm/bin/bpm stop cube_sync"
   group vcap
+<% else %>
+check process cube_sync
+  with pidfile /var/vcap/sys/run/cube_sync/cube_sync.pid
+  start program "/var/vcap/jobs/cube_sync/bin/sync_ctl start"
+  stop program "/var/vcap/jobs/cube_sync/bin/sync_ctl stop"
+  group vcap
+<% end %>

--- a/jobs/cube_sync/spec
+++ b/jobs/cube_sync/spec
@@ -2,13 +2,20 @@
 name: cube_sync
 
 templates:
+  sync_ctl.erb: bin/sync_ctl
+  sync_as_vcap.erb: bin/sync_as_vcap
   bmp.yml.erb: config/bpm.yml
   kube_config.erb: config/kube.yml
 
 packages:
+  - pid_utils
   - cube
 
 properties:
+  bpm.enabled:
+    description: "Enable Bosh Process Manager"
+    default: false
+
   cube_sync.ccAPI:
     description: "The API endpoint of the Cloud Controller"
   cube_sync.ccUser:

--- a/jobs/cube_sync/templates/bmp.yml.erb
+++ b/jobs/cube_sync/templates/bmp.yml.erb
@@ -18,8 +18,7 @@ processes:
     - <%= p('cube_sync.adminUser') %>
     - --adminPass
     - <%= p('cube_sync.adminPassword') %>
-    - --skipSslValidation
-    - <%= p('cube_sync.skipSslValidation') %>
+    <% if p("cube_sync.skipSslValidation") %>- --skipSslValidation<% end %>
     limits:
       memory: 3G
       processes: 10

--- a/jobs/cube_sync/templates/sync_as_vcap.erb
+++ b/jobs/cube_sync/templates/sync_as_vcap.erb
@@ -1,0 +1,20 @@
+#!/bin/bash -e
+
+run_dir=/var/vcap/sys/run/cube_sync
+log_dir=/var/vcap/sys/log/cube_sync
+conf_dir=/var/vcap/jobs/cube_sync/config
+pidfile=$run_dir/cube_sync.pid
+
+echo $$ > $pidfile
+
+exec /var/vcap/packages/cube/bin/cube sync \
+  --ccApi <%= p('cube_sync.ccAPI') %> \
+  --ccUser <%= p('cube_sync.ccUser') %> \
+  --ccPass <%= p('cube_sync.ccPassword') %> \
+  --kubeconfig="$conf_dir/kube.yml" \
+  --backend <%= p('cube_sync.backend') %> \
+  --adminUser <%= p('cube_sync.adminUser') %> \
+  --adminPass <%= p('cube_sync.adminPassword') %> \
+  <% if p("cube_sync.skipSslValidation") %>--skipSslValidation<% end %> \
+  2> >(tee -a $log_dir/cube_sync.stderr.log | logger -p user.error -t vcap.sync) \
+  1> >(tee -a $log_dir/cube_sync.stdout.log | logger -t vcap.sync)

--- a/jobs/cube_sync/templates/sync_ctl.erb
+++ b/jobs/cube_sync/templates/sync_ctl.erb
@@ -1,0 +1,39 @@
+#!/bin/bash -e
+
+run_dir=/var/vcap/sys/run/cube_sync
+log_dir=/var/vcap/sys/log/cube_sync
+conf_dir=/var/vcap/jobs/cube_sync/config
+
+pidfile=$run_dir/cube_sync.pid
+
+source /var/vcap/packages/pid_utils/pid_utils.sh
+
+case $1 in
+
+  start)
+    pid_guard $pidfile "cube_sync"
+
+    mkdir -p $run_dir
+    chown -R vcap:vcap $run_dir
+
+    mkdir -p $log_dir
+    chown -R vcap:vcap $log_dir
+
+    # Allowed number of open file descriptors
+    ulimit -n 100000
+
+    exec chpst -u vcap:vcap /var/vcap/jobs/cube_sync/bin/sync_as_vcap
+
+    ;;
+
+  stop)
+    kill_and_wait $pidfile
+
+    ;;
+
+  *)
+    echo "Usage: sync_ctl {start|stop}"
+
+    ;;
+
+esac

--- a/operations/cube-bosh-operations-no-bpm.yml
+++ b/operations/cube-bosh-operations-no-bpm.yml
@@ -23,13 +23,10 @@
       release: cflinuxfs2
     - name: cube_registry
       release: cube
-      properties:
-        bpm: { enabled: true }
     - name: cube_stager
       release: cube
       properties:
         cube_stager:
-          bpm: { enabled: true }
           ccAPI: "((cc_api))"
           ccUser: "internal_user"
           ccPassword: "((cc_internal_api_password))"
@@ -42,7 +39,6 @@
       release: cube
       properties:
         cube_sync:
-          bpm: { enabled: true }
           ccAPI: "((cc_api))"
           ccUser: "internal_user"
           ccPassword: "((cc_internal_api_password))"

--- a/packages/pid_utils/packaging
+++ b/packages/pid_utils/packaging
@@ -1,0 +1,3 @@
+set -e -x
+
+cp -a pid_utils.sh ${BOSH_INSTALL_TARGET}

--- a/packages/pid_utils/spec
+++ b/packages/pid_utils/spec
@@ -1,0 +1,5 @@
+---
+name: pid_utils
+
+files:
+  - pid_utils.sh

--- a/src/pid_utils.sh
+++ b/src/pid_utils.sh
@@ -1,0 +1,187 @@
+SCRIPT=$(basename $0)
+mkdir -p /var/vcap/sys/log/monit
+
+exec 1>> /var/vcap/sys/log/monit/$SCRIPT.log
+exec 2>> /var/vcap/sys/log/monit/$SCRIPT.err.log
+
+echo "------------ `basename $0` $* at `date` --------------" | tee /dev/stderr
+
+function pid_is_running() {
+  declare pid="$1"
+  ps -p "${pid}" >/dev/null 2>&1
+}
+
+# pid_guard
+#
+# @param pidfile
+# @param name [String] an arbitrary name that might show up in STDOUT on errors
+#
+# Run this before attempting to start new processes that may use the same :pidfile:.
+# If an old process is running on the pid found in the :pidfile:, exit 1. Otherwise,
+# remove the stale :pidfile: if it exists.
+#
+function pid_guard() {
+  declare pidfile="$1" name="$2"
+
+  echo "------------ STARTING $(basename "$0") at $(date) --------------" | tee /dev/stderr
+
+  if [ ! -f "${pidfile}" ]; then
+    return 0
+  fi
+
+  local pid
+  pid=$(head -1 "${pidfile}")
+
+  if pid_is_running "${pid}"; then
+    echo "${name} is already running, please stop it first"
+    exit 1
+  fi
+
+  echo "Removing stale pidfile"
+  rm "${pidfile}"
+}
+
+# wait_pid_death
+#
+# @param pid
+# @param timeout
+#
+# Watch a :pid: for :timeout: seconds, waiting for it to die.
+# If it dies before :timeout:, exit 0. If not, exit 1.
+#
+# Note that this should be run in a subshell, so that the current
+# shell does not exit.
+#
+function wait_pid_death() {
+  declare pid="$1" timeout="$2"
+
+  local countdown
+  countdown=$(( timeout * 10 ))
+
+  while true; do
+    if ! pid_is_running "${pid}"; then
+      return 0
+    fi
+
+    if [ ${countdown} -le 0 ]; then
+      return 1
+    fi
+
+    countdown=$(( countdown - 1 ))
+    sleep 0.1
+  done
+}
+
+# kill_and_wait
+#
+# @param pidfile
+# @param timeout [default 25s]
+#
+# For a pid found in :pidfile:, send a `kill`, then wait for :timeout: seconds to
+# see if it dies on its own. If not, send it a `kill -9`. If the process does die,
+# exit 0 and remove the :pidfile:. If after all of this, the process does not actually
+# die, exit 1.
+#
+# Note:
+# Monit default timeout for start/stop is 30s
+# Append 'with timeout {n} seconds' to monit start/stop program configs
+#
+function kill_and_wait() {
+  declare pidfile="$1" timeout="${2:-25}" sigkill_on_timeout="${3:-1}"
+
+  if [ ! -f "${pidfile}" ]; then
+    echo "Pidfile ${pidfile} doesn't exist"
+    exit 0
+  fi
+
+  local pid
+  pid=$(head -1 "${pidfile}")
+
+  if [ -z "${pid}" ]; then
+    echo "Unable to get pid from ${pidfile}"
+    exit 1
+  fi
+
+  if ! pid_is_running "${pid}"; then
+    echo "Process ${pid} is not running"
+    rm -f "${pidfile}"
+    exit 0
+  fi
+
+  echo "Killing ${pidfile}: ${pid} "
+  kill "${pid}"
+
+  if ! wait_pid_death "${pid}" "${timeout}"; then
+    if [ "${sigkill_on_timeout}" = "1" ]; then
+      echo "Kill timed out, using kill -9 on ${pid}"
+      kill -9 "${pid}"
+      sleep 0.5
+    fi
+  fi
+
+  if pid_is_running "${pid}"; then
+    echo "Timed Out"
+    exit 1
+  else
+    echo "Stopped"
+    rm -f "${pidfile}"
+  fi
+}
+
+check_mount() {
+  opts=$1
+  exports=$2
+  mount_point=$3
+
+  if grep -qs $mount_point /proc/mounts; then
+    echo "Found NFS mount $mount_point"
+  else
+    echo "Mounting NFS..."
+    mount $opts $exports $mount_point
+    if [ $? != 0 ]; then
+      echo "Cannot mount NFS from $exports to $mount_point, exiting..."
+      exit 1
+    fi
+  fi
+}
+
+# Check the syntax of a sudoers file.
+check_sudoers() {
+  /usr/sbin/visudo -c -f "$1"
+}
+
+# Check the syntax of a sudoers file and if it's ok install it.
+install_sudoers() {
+  src="$1"
+  dest="$2"
+
+  check_sudoers "$src"
+
+  if [ $? -eq 0 ]; then
+    chown root:root "$src"
+    chmod 0440 "$src"
+    cp -p "$src" "$dest"
+  else
+    echo "Syntax error in sudoers file $src"
+    exit 1
+  fi
+}
+
+# Add a line to a file if it is not already there.
+file_must_include() {
+  file="$1"
+  line="$2"
+
+  # Protect against empty $file so it doesn't wait for input on stdin.
+  if [ -n "$file" ]; then
+    grep --quiet "$line" "$file" || echo "$line" >> "$file"
+  else
+    echo 'File name is required'
+    exit 1
+  fi
+}
+
+running_in_container() {
+  # look for a non-root cgroup
+  grep --quiet --invert-match ':/$' /proc/self/cgroup
+}


### PR DESCRIPTION
The usage of BPM in cube-release was made configurable by reintroducing
the control scripts for registry and sync as well as a new control script
for stager. An additional operations file was added in case you do not
want to use BPM, for example in combination with fissile.

Also, we fixed the ERB for --skipSslValidation in stager in sync control
scripts. You cannot use `--skipSslValidation true`, but only the argument
itself or omit it if not needed.

Tested against BOSH Lite.

Signed-off-by: James Tuddenham <TUDDENHA@uk.ibm.com>